### PR TITLE
feat(daemon): add multi-config support for independent project management

### DIFF
--- a/docs/plans/20260307-multi-config-support.md
+++ b/docs/plans/20260307-multi-config-support.md
@@ -1,0 +1,235 @@
+# Multi-Config Support for Turtle Harbor
+
+## Overview
+Turtle Harbor currently stores a single global `config_path`, which breaks when managing scripts from multiple `scripts.yml` files across different projects. This refactor makes config_path per-script, enabling true multi-project support — like docker-compose, but each project has its own `scripts.yml`.
+
+### Problems solved
+1. **Cron restore bug**: After daemon restart, cron schedules for stopped cron-scripts are not restored
+2. **`th down` kills everything**: Stops ALL scripts from ALL configs instead of only current project
+3. **`th ps` shows everything**: Shows all scripts globally instead of filtering by current config
+4. **Default context bug**: Process inherits daemon's cwd instead of config directory when `context` is not set
+
+### New feature
+- **`th list`** command: Shows ALL scripts from all configs with config source column
+
+## Context
+- `src/daemon/state.rs` — `RunningState` has single `config_path: Option<PathBuf>`, `ScriptState` has no config reference
+- `src/daemon/config_manager.rs` — stores single `config: Option<Config>`
+- `src/daemon/daemon_core.rs` — `restore_state` skips Stopped scripts, only restores from single config
+- `src/common/ipc.rs` — `Down`, `Ps`, `Reload` commands carry no config_path
+- `src/daemon/process_supervisor.rs:75-78` — only sets `current_dir` when `context` is `Some`
+- `src/bin/th.rs` — no `List` command, `Down`/`Ps`/`Reload` don't pass config_path
+
+## Development Approach
+- **testing approach**: Regular (code first, then tests)
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+- **CRITICAL: all tests must pass before starting next task**
+- **CRITICAL: update this plan file when scope changes during implementation**
+- maintain backward compatibility with existing state.json format
+
+## Testing Strategy
+- **unit tests**: required for every task
+- test state migration (old format → new format)
+- test ConfigManager multi-config operations
+- test name collision detection
+- test command routing with config_path filtering
+
+## Progress Tracking
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with + prefix
+- document issues/blockers with warning prefix
+- update plan if implementation deviates from original scope
+
+## Implementation Steps
+
+### Task 1: Add config_path to ScriptState and migrate RunningState
+
+**Files:**
+- Modify: `src/daemon/state.rs`
+
+- [ ] add `config_path: Option<PathBuf>` field with `#[serde(default)]` to `ScriptState`
+- [ ] add migration logic in `RunningState::load`: if `ScriptState.config_path` is `None`, populate from top-level `RunningState.config_path`
+- [ ] keep `RunningState.config_path` field for backward compat during load, but stop writing it on save
+- [ ] write tests for loading old format state.json (without per-script config_path)
+- [ ] write tests for loading new format state.json (with per-script config_path)
+- [ ] write tests for migration: old format scripts get config_path from top-level field
+- [ ] run tests — must pass before task 2
+
+### Task 2: Refactor ConfigManager to multi-config
+
+**Files:**
+- Modify: `src/daemon/config_manager.rs`
+
+- [ ] change `config: Option<Config>` to `configs: HashMap<PathBuf, Config>`
+- [ ] change `config_path: Option<PathBuf>` to derived from HashMap keys
+- [ ] update `load(&mut self, path: &Path)` to insert into HashMap
+- [ ] update `config()` → `config(&self, config_path: &Path) -> Result<&Config>`
+- [ ] update `config_dir()` → `config_dir(&self, config_path: &Path) -> PathBuf`
+- [ ] update `script()` → `script(&self, config_path: &Path, name: &str) -> Option<&Script>`
+- [ ] update `has_script()` → `has_script(&self, config_path: &Path, name: &str) -> bool`
+- [ ] update `script_names()` → `script_names(&self, config_path: &Path) -> Vec<String>`
+- [ ] update `log_dir()` → `log_dir(&self, config_path: &Path) -> Option<&Path>`
+- [ ] update `loki_config()` → `loki_config(&self, config_path: &Path) -> Option<&LokiConfig>`
+- [ ] update `reload()` → `reload(&mut self, config_path: &Path) -> Result<ConfigDiff>`
+- [ ] add `all_config_paths(&self) -> Vec<PathBuf>` method
+- [ ] add `has_script_globally(&self, name: &str) -> Option<PathBuf>` — returns config_path if name exists in any config
+- [ ] write tests for multi-config load (two different configs)
+- [ ] write tests for script lookup across configs
+- [ ] write tests for reload of specific config
+- [ ] write tests for `has_script_globally` name collision detection
+- [ ] run tests — must pass before task 3
+
+### Task 3: Update IPC protocol — Command and Response enums
+
+**Files:**
+- Modify: `src/common/ipc.rs`
+
+- [ ] add `config_path: PathBuf` to `Command::Down`
+- [ ] change `Command::Ps` to `Ps { config_path: Option<PathBuf> }` (None = show all)
+- [ ] add `config_path: PathBuf` to `Command::Reload`
+- [ ] add `config_path: Option<PathBuf>` field to `ProcessInfo` (for `th list` config column)
+- [ ] run tests — must pass before task 4
+
+### Task 4: Update CLI — add List command and pass config_path
+
+**Files:**
+- Modify: `src/bin/th.rs`
+
+- [ ] add `List` variant to `Commands` enum
+- [ ] update `Down` match arm to pass `config_path` in `Command::Down`
+- [ ] update `Ps` match arm to pass `Some(config_path)` in `Command::Ps`
+- [ ] add `List` match arm: send `Command::Ps { config_path: None }`
+- [ ] update `Reload` match arm to pass `config_path` in `Command::Reload`
+- [ ] add `print_process_list_table_with_config` function for `th list` output (adds CONFIG column showing last 2 path components)
+- [ ] route `List` response through the new table printer
+- [ ] run tests — must pass before task 5
+
+### Task 5: Refactor DaemonCore — config_path-aware operations
+
+**Files:**
+- Modify: `src/daemon/daemon_core.rs`
+
+This is the largest task. All script operations become config_path-aware.
+
+- [ ] remove `self.state.config_path` usage from `handle_command` (Up no longer sets global config_path)
+- [ ] update `start_scripts` to accept `config_path: &Path`, pass it through to `start_script`
+- [ ] update `start_script` to accept `config_path: &Path`, use `self.config.script(config_path, name)` and `self.config.config_dir(config_path)`
+- [ ] update `start_script` to pass config_path to `update_script_state`
+- [ ] update `stop_scripts` to accept `config_path: Option<&Path>`: when Some, filter by config_path from state; when None, stop all
+- [ ] update `stop_script` to pass config_path to `update_script_state`
+- [ ] update `handle_command` for `Down { config_path, name }`: pass config_path to `stop_scripts`
+- [ ] update `handle_command` for `Ps { config_path }`: filter `full_status_list` by config_path when Some
+- [ ] update `handle_command` for `Reload { config_path }`: reload specific config
+- [ ] update `handle_command` for `Up`: check name collisions via `config.has_script_globally()` before starting
+- [ ] update `full_status_list` to include `config_path` in `ProcessInfo` (from state)
+- [ ] update `update_script_state` to accept and store `config_path` in `ScriptState`
+- [ ] update `sync_settings` to handle per-config log_dir and loki (use first config's settings or merge)
+- [ ] update `handle_process_exit`: retrieve config_path from `self.state.scripts` by name
+- [ ] update `handle_cron_tick`: retrieve config_path from `self.state.scripts` by name
+- [ ] update `handle_restart_after_backoff`: retrieve config_path from `self.state.scripts` by name
+- [ ] update `should_restart`: use config_path to look up script definition
+- [ ] run tests — must pass before task 6
+
+### Task 6: Fix restore_state for cron scripts
+
+**Files:**
+- Modify: `src/daemon/daemon_core.rs`
+
+- [ ] refactor `restore_state` to group `ScriptState` by `config_path`
+- [ ] for each unique config_path, call `self.config.load(config_path)`
+- [ ] restore running scripts (existing behavior, now config-aware)
+- [ ] register cron schedules for ALL scripts with cron expressions (not just running ones) — this is the core cron bug fix
+- [ ] skip scripts with `explicitly_stopped = true` from cron registration
+- [ ] run tests — must pass before task 7
+
+### Task 7: Fix default context (Bug 3)
+
+**Files:**
+- Modify: `src/daemon/process_supervisor.rs`
+
+- [ ] change `if let Some(context) = script_def.resolved_context(config_dir)` to always set `current_dir`
+- [ ] use `script_def.resolved_context(config_dir).unwrap_or_else(|| config_dir.to_path_buf())`
+- [ ] write test verifying current_dir is set to config_dir when context is None
+- [ ] run tests — must pass before task 8
+
+### Task 8: Add ScriptNameConflict error
+
+**Files:**
+- Modify: `src/common/error.rs`
+
+- [ ] add `ScriptNameConflict { name: String, existing_config: PathBuf }` variant to Error enum
+- [ ] run tests — must pass before task 9
+
+### Task 9: Verify acceptance criteria
+
+- [ ] verify cron schedules restore after daemon restart for stopped cron-scripts
+- [ ] verify `th down` only stops scripts from current config
+- [ ] verify `th ps` only shows scripts from current config
+- [ ] verify `th list` shows all scripts with config column
+- [ ] verify default context falls back to config directory
+- [ ] verify name collision produces clear error message
+- [ ] verify old state.json format migrates correctly
+- [ ] run full test suite: `cargo test`
+
+### Task 10: [Final] Update documentation
+
+- [ ] update CLAUDE.md Architecture section to reflect multi-config support
+- [ ] update Configuration section to mention multi-config behavior
+- [ ] move this plan to `docs/plans/completed/`
+
+## Technical Details
+
+### State format migration
+
+Old format:
+```json
+{
+  "version": 2,
+  "config_path": "/path/to/scripts.yml",
+  "scripts": [
+    {"name": "foo", "status": "Running", ...}
+  ]
+}
+```
+
+New format:
+```json
+{
+  "version": 3,
+  "scripts": [
+    {"name": "foo", "config_path": "/path/to/scripts.yml", "status": "Running", ...}
+  ]
+}
+```
+
+Migration: on load, if script has no `config_path`, copy from top-level `config_path`.
+
+### Config_path resolution
+- CLI canonicalizes path via `std::fs::canonicalize` (already done in `th.rs:109`)
+- Same file always produces same key in ConfigManager HashMap
+- config_dir = parent of config_path
+
+### Name collision check
+- On `th up`, before starting scripts, check `config.has_script_globally(name)`
+- If name exists in a different config_path, return `Error::ScriptNameConflict`
+
+### th list output format
+```
+NAME                 PID      STATUS           UPTIME     RESTARTS  CONFIG
+----------------------------------------------------------------------------------
+calendar             -        exited (0)       00:00:00   0         environment/scripts
+podcast-transcriber  49582    running          56:02:49   0         tuclaw-workspace
+tm-backup-checker    -        exited (0)       00:00:00   0         environment/scripts
+```
+
+CONFIG shows last 2 components of config directory path.
+
+## Post-Completion
+
+**Manual verification:**
+- test with two separate `scripts.yml` files from different projects
+- test daemon restart preserves cron schedules for both configs
+- test `th down` in one project doesn't affect the other
+- test `th ps` vs `th list` output differences

--- a/src/bin/th.rs
+++ b/src/bin/th.rs
@@ -22,6 +22,7 @@ pub enum Commands {
     Up { script_name: Option<String> },
     Down { script_name: Option<String> },
     Ps,
+    List,
     Logs {
         script_name: Option<String>,
         #[arg(short = 'n', long, default_value = "100")]
@@ -58,6 +59,25 @@ pub fn format_status(status: ProcessStatus, exit_code: Option<i32>) -> ColoredSt
     }
 }
 
+fn short_config_label(config_path: Option<&PathBuf>) -> String {
+    let Some(path) = config_path else {
+        return "-".to_string();
+    };
+    let parent = path.parent().unwrap_or(path);
+    let components: Vec<&str> = parent
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    let len = components.len();
+    if len >= 2 {
+        format!("{}/{}", components[len - 2], components[len - 1])
+    } else if len == 1 {
+        components[0].to_string()
+    } else {
+        path.display().to_string()
+    }
+}
+
 fn print_process_list_table(processes: &[ProcessInfo]) {
     if processes.is_empty() {
         println!("No scripts registered. Run 'th up' to start scripts.");
@@ -90,6 +110,40 @@ fn print_process_list_table(processes: &[ProcessInfo]) {
     }
 }
 
+fn print_process_list_table_with_config(processes: &[ProcessInfo]) {
+    if processes.is_empty() {
+        println!("No scripts registered. Run 'th up' to start scripts.");
+        return;
+    }
+
+    println!(
+        "{:<20} {:<8} {:<16} {:<10} {:<8} {:<24}",
+        "NAME".bold(),
+        "PID".bold(),
+        "STATUS".bold(),
+        "UPTIME".bold(),
+        "RESTARTS".bold(),
+        "CONFIG".bold()
+    );
+    println!("{}", "-".repeat(90));
+    for process in processes {
+        let pid = if process.pid > 0 {
+            process.pid.to_string()
+        } else {
+            "-".to_string()
+        };
+        println!(
+            "{:<20} {:<8} {:<16} {:<10} {:<8} {:<24}",
+            process.name,
+            pid,
+            format_status(process.status, process.exit_code),
+            format_duration(process.uptime),
+            process.restart_count,
+            short_config_label(process.config_path.as_ref())
+        );
+    }
+}
+
 #[tokio::main]
 pub async fn main() {
     let cli = Cli::parse();
@@ -118,7 +172,7 @@ async fn run(cli: Cli) -> Result<()> {
             }
         }
         Commands::Down { script_name } => {
-            let response = commands::send_command(Command::Down { name: script_name }).await?;
+            let response = commands::send_command(Command::Down { name: script_name, config_path }).await?;
             match response {
                 Response::Success => println!("Scripts stopped successfully"),
                 Response::Error(e) => eprintln!("Error: {}", e),
@@ -126,11 +180,19 @@ async fn run(cli: Cli) -> Result<()> {
             }
         }
         Commands::Ps => {
-            let response = commands::send_command(Command::Ps).await?;
+            let response = commands::send_command(Command::Ps { config_path: Some(config_path) }).await?;
             match response {
                 Response::ProcessList(processes) => print_process_list_table(&processes),
                 Response::Error(e) => eprintln!("Error retrieving process list: {}", e),
                 _ => eprintln!("Unexpected response for ps command"),
+            }
+        }
+        Commands::List => {
+            let response = commands::send_command(Command::Ps { config_path: None }).await?;
+            match response {
+                Response::ProcessList(processes) => print_process_list_table_with_config(&processes),
+                Response::Error(e) => eprintln!("Error retrieving process list: {}", e),
+                _ => eprintln!("Unexpected response for list command"),
             }
         }
         Commands::Logs {
@@ -174,7 +236,7 @@ async fn run(cli: Cli) -> Result<()> {
             }
         }
         Commands::Reload => {
-            let response = commands::send_command(Command::Reload).await?;
+            let response = commands::send_command(Command::Reload { config_path }).await?;
             match response {
                 Response::Success => println!("Configuration reloaded"),
                 Response::Error(e) => eprintln!("Reload error: {}", e),

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -7,7 +7,7 @@ use std::ffi::OsString;
 const DEFAULT_MAX_RESTARTS: u32 = 5;
 const DEFAULT_MAX_RESTARTS_CRON: u32 = 3;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub settings: Settings,
     pub scripts: HashMap<String, Script>,
@@ -20,7 +20,7 @@ pub struct LokiConfig {
     pub labels: Option<HashMap<String, String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub log_dir: PathBuf,
     #[serde(default)]

--- a/src/common/ipc.rs
+++ b/src/common/ipc.rs
@@ -23,10 +23,10 @@ impl Profile {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Command {
     Up { name: Option<String>, config_path: std::path::PathBuf },
-    Down { name: Option<String> },
-    Ps,
+    Down { name: Option<String>, config_path: std::path::PathBuf },
+    Ps { config_path: Option<std::path::PathBuf> },
     Logs { name: Option<String>, tail: u32, follow: bool },
-    Reload,
+    Reload { config_path: std::path::PathBuf },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -46,6 +46,8 @@ pub struct ProcessInfo {
     pub restart_count: u32,
     #[serde(default)]
     pub exit_code: Option<i32>,
+    #[serde(default)]
+    pub config_path: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]

--- a/src/daemon/config_manager.rs
+++ b/src/daemon/config_manager.rs
@@ -1,6 +1,6 @@
 use crate::common::config::{Config, LokiConfig, Script};
 use crate::common::error::{Error, Result};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 pub struct ConfigDiff {
@@ -10,88 +10,97 @@ pub struct ConfigDiff {
 }
 
 pub struct ConfigManager {
-    config: Option<Config>,
-    config_path: Option<PathBuf>,
+    configs: HashMap<PathBuf, Config>,
 }
 
 impl ConfigManager {
     pub fn new() -> Self {
         Self {
-            config: None,
-            config_path: None,
+            configs: HashMap::new(),
         }
     }
 
     pub fn load(&mut self, path: &Path) -> Result<()> {
         let config = Config::load(path)?;
-        self.config = Some(config);
-        self.config_path = Some(path.to_path_buf());
+        self.configs.insert(path.to_path_buf(), config);
         Ok(())
     }
 
-    pub fn config(&self) -> Result<&Config> {
-        self.config.as_ref().ok_or(Error::ConfigNotLoaded)
+    pub fn config(&self, config_path: &Path) -> Result<&Config> {
+        self.configs.get(config_path).ok_or(Error::ConfigNotLoaded)
     }
 
-    pub fn config_dir(&self) -> Option<PathBuf> {
-        self.config_path
-            .as_ref()
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    pub fn config_dir(&self, config_path: &Path) -> PathBuf {
+        config_path
+            .parent()
+            .map(|d| d.to_path_buf())
+            .unwrap_or_default()
     }
 
-    pub fn script(&self, name: &str) -> Option<&Script> {
-        self.config.as_ref().and_then(|c| c.scripts.get(name))
+    pub fn script(&self, config_path: &Path, name: &str) -> Option<&Script> {
+        self.configs
+            .get(config_path)
+            .and_then(|c| c.scripts.get(name))
     }
 
-    pub fn script_names(&self) -> Vec<String> {
-        self.config
-            .as_ref()
+    pub fn script_names(&self, config_path: &Path) -> Vec<String> {
+        self.configs
+            .get(config_path)
             .map(|c| c.scripts.keys().cloned().collect())
             .unwrap_or_default()
     }
 
-    pub fn has_script(&self, name: &str) -> bool {
-        self.config
-            .as_ref()
+    pub fn has_script(&self, config_path: &Path, name: &str) -> bool {
+        self.configs
+            .get(config_path)
             .map_or(false, |c| c.scripts.contains_key(name))
     }
 
-    pub fn log_dir(&self) -> Option<&Path> {
-        self.config.as_ref().map(|c| c.settings.log_dir.as_path())
+    pub fn has_script_globally(&self, name: &str) -> Option<PathBuf> {
+        self.configs.iter().find_map(|(path, config)| {
+            if config.scripts.contains_key(name) {
+                Some(path.clone())
+            } else {
+                None
+            }
+        })
     }
 
-    pub fn loki_config(&self) -> Option<&LokiConfig> {
-        self.config.as_ref().and_then(|c| c.settings.loki.as_ref())
+    pub fn log_dir(&self, config_path: &Path) -> Option<&Path> {
+        self.configs
+            .get(config_path)
+            .map(|c| c.settings.log_dir.as_path())
     }
 
-    pub fn reload(&mut self) -> Result<ConfigDiff> {
-        let config_path = self
-            .config_path
-            .clone()
-            .ok_or(Error::ConfigNotLoaded)?;
+    pub fn loki_config(&self, config_path: &Path) -> Option<&LokiConfig> {
+        self.configs
+            .get(config_path)
+            .and_then(|c| c.settings.loki.as_ref())
+    }
 
+    pub fn reload(&mut self, config_path: &Path) -> Result<ConfigDiff> {
         tracing::info!(config = ?config_path, "Reloading configuration");
-        let new_config = Config::load(&config_path)?;
-        let old_config = self.config.replace(new_config);
 
-        let Some(old_config) = old_config else {
-            return Ok(ConfigDiff {
-                added: self.script_names(),
-                removed: Vec::new(),
-                changed: Vec::new(),
-            });
-        };
+        let old_config = self
+            .configs
+            .get(config_path)
+            .ok_or(Error::ConfigNotLoaded)?
+            .clone();
+
+        let new_config = Config::load(config_path)?;
+        self.configs.insert(config_path.to_path_buf(), new_config);
+
+        let new_config = self.configs.get(config_path).expect("just inserted");
 
         let old_names: HashSet<String> = old_config.scripts.keys().cloned().collect();
-        let new_names: HashSet<String> = self.script_names().into_iter().collect();
+        let new_names: HashSet<String> = new_config.scripts.keys().cloned().collect();
 
         let removed = old_names.difference(&new_names).cloned().collect();
         let added = new_names.difference(&old_names).cloned().collect();
 
-        let new_scripts = &self.config.as_ref().expect("config just replaced").scripts;
         let changed = old_names
             .intersection(&new_names)
-            .filter(|name| old_config.scripts[*name] != new_scripts[*name])
+            .filter(|name| old_config.scripts[*name] != new_config.scripts[*name])
             .cloned()
             .collect();
 
@@ -100,5 +109,164 @@ impl ConfigManager {
             removed,
             changed,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_config(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    const CONFIG_A: &str = r#"
+settings:
+  log_dir: "./logs"
+scripts:
+  script_a1:
+    command: "echo a1"
+    restart_policy: "never"
+  script_a2:
+    command: "echo a2"
+    restart_policy: "always"
+"#;
+
+    const CONFIG_B: &str = r#"
+settings:
+  log_dir: "./logs-b"
+scripts:
+  script_b1:
+    command: "echo b1"
+    restart_policy: "never"
+"#;
+
+    #[test]
+    fn load_multiple_configs() {
+        let file_a = write_config(CONFIG_A);
+        let file_b = write_config(CONFIG_B);
+        let mut mgr = ConfigManager::new();
+
+        mgr.load(file_a.path()).unwrap();
+        mgr.load(file_b.path()).unwrap();
+
+        assert!(mgr.has_script(file_a.path(), "script_a1"));
+        assert!(mgr.has_script(file_a.path(), "script_a2"));
+        assert!(!mgr.has_script(file_a.path(), "script_b1"));
+        assert!(mgr.has_script(file_b.path(), "script_b1"));
+        assert!(!mgr.has_script(file_b.path(), "script_a1"));
+    }
+
+    #[test]
+    fn script_lookup_across_configs() {
+        let file_a = write_config(CONFIG_A);
+        let file_b = write_config(CONFIG_B);
+        let mut mgr = ConfigManager::new();
+
+        mgr.load(file_a.path()).unwrap();
+        mgr.load(file_b.path()).unwrap();
+
+        let script = mgr.script(file_a.path(), "script_a1").unwrap();
+        assert_eq!(script.command, "echo a1");
+
+        let script = mgr.script(file_b.path(), "script_b1").unwrap();
+        assert_eq!(script.command, "echo b1");
+
+        assert!(mgr.script(file_a.path(), "script_b1").is_none());
+    }
+
+    #[test]
+    fn has_script_globally_finds_across_configs() {
+        let file_a = write_config(CONFIG_A);
+        let file_b = write_config(CONFIG_B);
+        let mut mgr = ConfigManager::new();
+
+        mgr.load(file_a.path()).unwrap();
+        mgr.load(file_b.path()).unwrap();
+
+        assert_eq!(
+            mgr.has_script_globally("script_a1").as_deref(),
+            Some(file_a.path())
+        );
+        assert_eq!(
+            mgr.has_script_globally("script_b1").as_deref(),
+            Some(file_b.path())
+        );
+        assert!(mgr.has_script_globally("nonexistent").is_none());
+    }
+
+    #[test]
+    fn script_names_per_config() {
+        let file_a = write_config(CONFIG_A);
+        let file_b = write_config(CONFIG_B);
+        let mut mgr = ConfigManager::new();
+
+        mgr.load(file_a.path()).unwrap();
+        mgr.load(file_b.path()).unwrap();
+
+        let mut names_a = mgr.script_names(file_a.path());
+        names_a.sort();
+        assert_eq!(names_a, vec!["script_a1", "script_a2"]);
+
+        let names_b = mgr.script_names(file_b.path());
+        assert_eq!(names_b, vec!["script_b1"]);
+
+        assert!(mgr.script_names(Path::new("/nonexistent")).is_empty());
+    }
+
+    #[test]
+    fn reload_detects_changes() {
+        let config_v1 = r#"
+settings:
+  log_dir: "./logs"
+scripts:
+  kept:
+    command: "echo kept"
+    restart_policy: "never"
+  removed:
+    command: "echo removed"
+    restart_policy: "never"
+  changed:
+    command: "echo old"
+    restart_policy: "never"
+"#;
+        let config_v2 = r#"
+settings:
+  log_dir: "./logs"
+scripts:
+  kept:
+    command: "echo kept"
+    restart_policy: "never"
+  added:
+    command: "echo added"
+    restart_policy: "never"
+  changed:
+    command: "echo new"
+    restart_policy: "never"
+"#;
+        let file = write_config(config_v1);
+        let mut mgr = ConfigManager::new();
+        mgr.load(file.path()).unwrap();
+
+        std::fs::write(file.path(), config_v2).unwrap();
+        let diff = mgr.reload(file.path()).unwrap();
+
+        assert_eq!(diff.added, vec!["added"]);
+        assert_eq!(diff.removed, vec!["removed"]);
+        assert_eq!(diff.changed, vec!["changed"]);
+    }
+
+    #[test]
+    fn config_dir_returns_parent() {
+        let mgr = ConfigManager::new();
+        assert_eq!(
+            mgr.config_dir(Path::new("/projects/foo/scripts.yml")),
+            PathBuf::from("/projects/foo")
+        );
     }
 }

--- a/src/daemon/daemon_core.rs
+++ b/src/daemon/daemon_core.rs
@@ -11,7 +11,7 @@ use crate::daemon::process_supervisor::ProcessSupervisor;
 use crate::daemon::state::{RunningState, ScriptState};
 use chrono::Local;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -138,24 +138,27 @@ impl DaemonCore {
         self.shutdown().await
     }
 
-    fn config_dir(&self) -> PathBuf {
-        self.config
-            .config_dir()
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
+    fn script_config_path(&self, name: &str) -> Option<PathBuf> {
+        self.state
+            .scripts
+            .iter()
+            .find(|s| s.name == name)
+            .and_then(|s| s.config_path.clone())
     }
 
-    fn sync_settings(&mut self) {
-        if let Some(log_dir) = self.config.log_dir() {
+    fn sync_settings(&mut self, config_path: &Path) {
+        if let Some(log_dir) = self.config.log_dir(config_path) {
+            let config_dir = self.config.config_dir(config_path);
             let resolved = if log_dir.is_absolute() {
                 log_dir.to_path_buf()
             } else {
-                self.config_dir().join(log_dir)
+                config_dir.join(log_dir)
             };
             self.supervisor.set_log_dir(resolved);
         }
 
         if self.loki_tx.is_none() {
-            if let Some(loki_config) = self.config.loki_config().cloned() {
+            if let Some(loki_config) = self.config.loki_config(config_path).cloned() {
                 let (tx, rx) = mpsc::channel(loki_shipper::CHANNEL_CAPACITY);
                 LokiShipper::spawn(rx, loki_config);
                 self.supervisor.set_loki_tx(tx.clone());
@@ -164,10 +167,16 @@ impl DaemonCore {
         }
     }
 
-    fn full_status_list(&self) -> Vec<ProcessInfo> {
+    fn full_status_list(&self, filter_config: Option<&Path>) -> Vec<ProcessInfo> {
         let mut result: HashMap<String, ProcessInfo> = HashMap::new();
 
         for script in &self.state.scripts {
+            if let Some(filter) = filter_config {
+                if script.config_path.as_deref() != Some(filter) {
+                    continue;
+                }
+            }
+
             let uptime = match script.status {
                 ProcessStatus::Running | ProcessStatus::Restarting => script
                     .last_started
@@ -190,12 +199,26 @@ impl DaemonCore {
                     uptime,
                     restart_count: script.restart_count,
                     exit_code: script.exit_code,
+                    config_path: script.config_path.clone(),
                 },
             );
         }
 
         for info in self.supervisor.status_list() {
-            result.insert(info.name.clone(), info);
+            if let Some(filter) = filter_config {
+                let script_config = self.script_config_path(&info.name);
+                if script_config.as_deref() != Some(filter) {
+                    continue;
+                }
+            }
+            let config_path = self.script_config_path(&info.name);
+            result.insert(
+                info.name.clone(),
+                ProcessInfo {
+                    config_path,
+                    ..info
+                },
+            );
         }
 
         let mut list: Vec<ProcessInfo> = result.into_values().collect();
@@ -209,18 +232,47 @@ impl DaemonCore {
                 if let Err(e) = self.config.load(&config_path) {
                     return Response::Error(e.to_string());
                 }
-                self.sync_settings();
-                self.state.config_path = Some(config_path);
-                match self.start_scripts(name).await {
+                self.sync_settings(&config_path);
+
+                if let Some(ref script_name) = name {
+                    if let Some(existing) = self.config.has_script_globally(script_name) {
+                        if existing != config_path {
+                            return Response::Error(format!(
+                                "script '{}' already registered from '{}'",
+                                script_name,
+                                existing.display()
+                            ));
+                        }
+                    }
+                } else {
+                    let new_names: Vec<String> = self.config.script_names(&config_path);
+                    for script_name in &new_names {
+                        if let Some(existing) = self.config.has_script_globally(script_name) {
+                            if existing != config_path {
+                                return Response::Error(format!(
+                                    "script '{}' already registered from '{}'",
+                                    script_name,
+                                    existing.display()
+                                ));
+                            }
+                        }
+                    }
+                }
+
+                match self.start_scripts(name, &config_path).await {
                     Ok(_) => Response::Success,
                     Err(e) => Response::Error(e.to_string()),
                 }
             }
-            Command::Down { name } => match self.stop_scripts(name).await {
-                Ok(_) => Response::Success,
-                Err(e) => Response::Error(e.to_string()),
-            },
-            Command::Ps => Response::ProcessList(self.full_status_list()),
+            Command::Down { name, config_path } => {
+                match self.stop_scripts(name, Some(&config_path)).await {
+                    Ok(_) => Response::Success,
+                    Err(e) => Response::Error(e.to_string()),
+                }
+            }
+            Command::Ps { config_path } => {
+                Response::ProcessList(self.full_status_list(config_path.as_deref()))
+            }
             Command::Logs {
                 name,
                 tail,
@@ -229,7 +281,7 @@ impl DaemonCore {
                 Ok(logs) => Response::Logs(logs),
                 Err(e) => Response::Error(e.to_string()),
             },
-            Command::Reload => match self.reload_config().await {
+            Command::Reload { config_path } => match self.reload_config(&config_path).await {
                 Ok(_) => Response::Success,
                 Err(e) => Response::Error(e.to_string()),
             },
@@ -250,7 +302,14 @@ impl DaemonCore {
         let code = exit_status.code().unwrap_or(-1);
         tracing::warn!(script = %name, exit_code = code, "Process exited with error");
 
-        match (self.config.script(name), self.supervisor.get(name)) {
+        let Some(config_path) = self.script_config_path(name) else {
+            return false;
+        };
+
+        match (
+            self.config.script(&config_path, name),
+            self.supervisor.get(name),
+        ) {
             (Some(def), Some(proc)) => {
                 matches!(def.restart_policy, RestartPolicy::Always)
                     && proc.restart_count < def.effective_max_restarts()
@@ -339,7 +398,12 @@ impl DaemonCore {
     }
 
     async fn handle_restart_after_backoff(&mut self, name: &str, restart_count: u32) {
-        if !self.config.has_script(name) {
+        let Some(config_path) = self.script_config_path(name) else {
+            tracing::info!(script = %name, "Skipping backoff restart - no config path");
+            return;
+        };
+
+        if !self.config.has_script(&config_path, name) {
             tracing::info!(script = %name, "Skipping backoff restart - script removed from config");
             return;
         }
@@ -359,15 +423,18 @@ impl DaemonCore {
             return;
         }
 
-        let script_def = match self.config.script(name).cloned() {
+        let script_def = match self.config.script(&config_path, name).cloned() {
             Some(def) => def,
             None => return,
         };
 
         tracing::info!(script = %name, restart_count, "Executing restart after backoff");
-        let config_dir = self.config_dir();
+        let config_dir = self.config.config_dir(&config_path);
         let broadcast_tx = self.register_log_channel(name);
-        match self.supervisor.start_script(name, &script_def, broadcast_tx, &config_dir) {
+        match self
+            .supervisor
+            .start_script(name, &script_def, broadcast_tx, &config_dir)
+        {
             Ok(ScriptStartResult::Started) => {
                 if let Some(proc) = self.supervisor.get_mut(name) {
                     proc.restart_count = restart_count;
@@ -390,18 +457,25 @@ impl DaemonCore {
     }
 
     async fn handle_cron_tick(&mut self, name: &str) {
-        if !self.config.has_script(name) {
+        let Some(config_path) = self.script_config_path(name) else {
+            return;
+        };
+
+        if !self.config.has_script(&config_path, name) {
             return;
         }
 
-        let script_def = match self.config.script(name).cloned() {
+        let script_def = match self.config.script(&config_path, name).cloned() {
             Some(def) => def,
             None => return,
         };
 
-        let config_dir = self.config_dir();
+        let config_dir = self.config.config_dir(&config_path);
         let broadcast_tx = self.register_log_channel(name);
-        match self.supervisor.start_script(name, &script_def, broadcast_tx, &config_dir) {
+        match self
+            .supervisor
+            .start_script(name, &script_def, broadcast_tx, &config_dir)
+        {
             Ok(ScriptStartResult::Started) => {
                 tracing::info!(script = %name, "Cron-triggered script started");
                 self.update_health_on_start(name).await;
@@ -421,10 +495,14 @@ impl DaemonCore {
         }
     }
 
-    async fn start_scripts(&mut self, name: Option<String>) -> Result<()> {
+    async fn start_scripts(
+        &mut self,
+        name: Option<String>,
+        config_path: &Path,
+    ) -> Result<()> {
         let names: Vec<String> = match name {
             Some(name) => vec![name],
-            None => self.config.config()?.scripts.keys().cloned().collect(),
+            None => self.config.config(config_path)?.scripts.keys().cloned().collect(),
         };
 
         {
@@ -437,26 +515,45 @@ impl DaemonCore {
         }
 
         for name in names {
-            self.start_script(&name).await?;
+            self.start_script(&name, config_path).await?;
         }
         Ok(())
     }
 
-    async fn stop_scripts(&mut self, name: Option<String>) -> Result<()> {
+    async fn stop_scripts(
+        &mut self,
+        name: Option<String>,
+        config_path: Option<&Path>,
+    ) -> Result<()> {
         let names: Vec<String> = match name {
             Some(name) => vec![name],
             None => {
                 let mut seen: HashSet<String> = HashSet::new();
                 let mut all: Vec<String> = Vec::new();
-                for name in self.supervisor.names() {
-                    seen.insert(name.clone());
-                    all.push(name);
-                }
+
                 for s in &self.state.scripts {
+                    if let Some(filter) = config_path {
+                        if s.config_path.as_deref() != Some(filter) {
+                            continue;
+                        }
+                    }
                     if seen.insert(s.name.clone()) {
                         all.push(s.name.clone());
                     }
                 }
+
+                for name in self.supervisor.names() {
+                    if let Some(filter) = config_path {
+                        let script_config = self.script_config_path(&name);
+                        if script_config.as_deref() != Some(filter) {
+                            continue;
+                        }
+                    }
+                    if seen.insert(name.clone()) {
+                        all.push(name);
+                    }
+                }
+
                 all
             }
         };
@@ -466,10 +563,10 @@ impl DaemonCore {
         Ok(())
     }
 
-    async fn start_script(&mut self, name: &str) -> Result<ScriptStartResult> {
+    async fn start_script(&mut self, name: &str, config_path: &Path) -> Result<ScriptStartResult> {
         let script_def = self
             .config
-            .config()?
+            .config(config_path)?
             .scripts
             .get(name)
             .ok_or_else(|| Error::ScriptNotFound {
@@ -478,14 +575,22 @@ impl DaemonCore {
             .clone();
 
         let cron = script_def.cron.clone();
-        let config_dir = self.config_dir();
+        let config_dir = self.config.config_dir(config_path);
         let broadcast_tx = self.register_log_channel(name);
-        let result = self.supervisor.start_script(name, &script_def, broadcast_tx, &config_dir)?;
+        let result = self
+            .supervisor
+            .start_script(name, &script_def, broadcast_tx, &config_dir)?;
 
         if matches!(result, ScriptStartResult::Started) {
             self.update_health_on_start(name).await;
-            self.update_script_state(name, ProcessStatus::Running, false, None)
-                .await?;
+            self.update_script_state_with_config(
+                name,
+                config_path,
+                ProcessStatus::Running,
+                false,
+                None,
+            )
+            .await?;
 
             if let Some(ref cron_expr) = cron {
                 if !self.cron.is_scheduled(name) {
@@ -512,7 +617,10 @@ impl DaemonCore {
             .await?;
 
         self.supervisor.stop_script(name).await?;
-        self.log_channels.lock().expect("log_channels mutex poisoned").remove(name);
+        self.log_channels
+            .lock()
+            .expect("log_channels mutex poisoned")
+            .remove(name);
         self.cron.cancel(name);
         tracing::info!(script = %name, "Script stopped successfully");
         Ok(())
@@ -521,7 +629,10 @@ impl DaemonCore {
     async fn shutdown(&mut self) -> Result<()> {
         self.supervisor.shutdown_all().await;
         self.cron.cancel_all();
-        self.log_channels.lock().expect("log_channels mutex poisoned").clear();
+        self.log_channels
+            .lock()
+            .expect("log_channels mutex poisoned")
+            .clear();
         Ok(())
     }
 
@@ -567,17 +678,15 @@ impl DaemonCore {
             let mut snapshot = self.health.write().await;
             for script in &self.state.scripts {
                 let state = match script.status {
-                    ProcessStatus::Running | ProcessStatus::Restarting => ScriptHealthState::Running,
+                    ProcessStatus::Running | ProcessStatus::Restarting => {
+                        ScriptHealthState::Running
+                    }
                     ProcessStatus::Failed => ScriptHealthState::Failed,
                     ProcessStatus::Stopped => {
-                        if script.exit_code.is_some() {
-                            if script.exit_code == Some(0) {
-                                ScriptHealthState::Succeeded
-                            } else {
-                                ScriptHealthState::Failed
-                            }
-                        } else {
+                        if script.exit_code == Some(0) || script.exit_code.is_none() {
                             ScriptHealthState::Succeeded
+                        } else {
+                            ScriptHealthState::Failed
                         }
                     }
                 };
@@ -598,49 +707,74 @@ impl DaemonCore {
             }
         }
 
-        if let Some(config_path) = self.state.config_path.clone() {
-            if config_path.exists() {
-                tracing::info!(config = ?config_path, "Loading config from state");
-                if let Err(e) = self.config.load(&config_path) {
-                    tracing::warn!(error = ?e, "Failed to load config from state, skipping restore");
-                    return Ok(());
+        let mut config_paths: Vec<PathBuf> = Vec::new();
+        for script in &self.state.scripts {
+            if let Some(ref cp) = script.config_path {
+                if !config_paths.contains(cp) {
+                    config_paths.push(cp.clone());
                 }
-                self.sync_settings();
-            } else {
-                tracing::warn!(config = ?config_path, "Stored config path no longer exists, skipping restore");
-                return Ok(());
             }
-        } else {
-            tracing::info!("No config path in state, skipping restore");
-            return Ok(());
+        }
+
+        for config_path in &config_paths {
+            if !config_path.exists() {
+                tracing::warn!(config = ?config_path, "Stored config path no longer exists, skipping");
+                continue;
+            }
+            tracing::info!(config = ?config_path, "Loading config from state");
+            if let Err(e) = self.config.load(config_path) {
+                tracing::warn!(config = ?config_path, error = ?e, "Failed to load config, skipping");
+                continue;
+            }
+            self.sync_settings(config_path);
         }
 
         let scripts: Vec<ScriptState> = self.state.scripts.clone();
-        for script in scripts {
-            if !matches!(script.status, ProcessStatus::Running | ProcessStatus::Restarting) || script.explicitly_stopped {
+        for script in &scripts {
+            if script.explicitly_stopped {
                 continue;
             }
-            if !self.config.has_script(&script.name) {
+            if !matches!(
+                script.status,
+                ProcessStatus::Running | ProcessStatus::Restarting
+            ) {
+                continue;
+            }
+            let Some(ref config_path) = script.config_path else {
+                tracing::info!(script = %script.name, "Skipping restoration - no config path");
+                continue;
+            };
+            if !self.config.has_script(config_path, &script.name) {
                 tracing::info!(script = %script.name, "Skipping restoration - no longer in config");
                 continue;
             }
             tracing::info!(script = %script.name, "Restoring script");
-            self.start_script(&script.name).await?;
+            if let Err(e) = self.start_script(&script.name, config_path).await {
+                tracing::error!(script = %script.name, error = ?e, "Failed to restore script");
+            }
         }
 
-        let cron_entries: Vec<(String, String)> = self
-            .config
-            .script_names()
-            .into_iter()
-            .filter(|name| !self.cron.is_scheduled(name))
-            .filter_map(|name| {
-                self.config
-                    .script(&name)
-                    .and_then(|def| def.cron.as_ref().map(|expr| (name, expr.clone())))
-            })
-            .collect();
-        for (name, cron_expr) in cron_entries {
-            self.cron.schedule(&name, &cron_expr);
+        for config_path in &config_paths {
+            let cron_entries: Vec<(String, String)> = self
+                .config
+                .script_names(config_path)
+                .into_iter()
+                .filter(|name| !self.cron.is_scheduled(name))
+                .filter(|name| {
+                    !scripts
+                        .iter()
+                        .any(|s| s.name == *name && s.explicitly_stopped)
+                })
+                .filter_map(|name| {
+                    self.config
+                        .script(config_path, &name)
+                        .and_then(|def| def.cron.as_ref().map(|expr| (name, expr.clone())))
+                })
+                .collect();
+
+            for (name, cron_expr) in cron_entries {
+                self.cron.schedule(&name, &cron_expr);
+            }
         }
 
         tracing::info!("State restoration completed");
@@ -673,6 +807,37 @@ impl DaemonCore {
         explicitly_stopped: bool,
         exit_code: Option<i32>,
     ) -> Result<()> {
+        let config_path = self.script_config_path(name);
+        self.update_script_state_inner(name, config_path, status, explicitly_stopped, exit_code)
+            .await
+    }
+
+    async fn update_script_state_with_config(
+        &mut self,
+        name: &str,
+        config_path: &Path,
+        status: ProcessStatus,
+        explicitly_stopped: bool,
+        exit_code: Option<i32>,
+    ) -> Result<()> {
+        self.update_script_state_inner(
+            name,
+            Some(config_path.to_path_buf()),
+            status,
+            explicitly_stopped,
+            exit_code,
+        )
+        .await
+    }
+
+    async fn update_script_state_inner(
+        &mut self,
+        name: &str,
+        config_path: Option<PathBuf>,
+        status: ProcessStatus,
+        explicitly_stopped: bool,
+        exit_code: Option<i32>,
+    ) -> Result<()> {
         let restart_count = self
             .supervisor
             .get(name)
@@ -682,6 +847,7 @@ impl DaemonCore {
 
         let script_state = ScriptState {
             name: name.to_string(),
+            config_path,
             status,
             last_started: start_time,
             last_stopped: if matches!(status, ProcessStatus::Stopped | ProcessStatus::Failed) {
@@ -699,9 +865,9 @@ impl DaemonCore {
         Ok(())
     }
 
-    async fn reload_config(&mut self) -> Result<()> {
-        let diff = self.config.reload()?;
-        self.sync_settings();
+    async fn reload_config(&mut self, config_path: &Path) -> Result<()> {
+        let diff = self.config.reload(config_path)?;
+        self.sync_settings(config_path);
 
         for name in diff.removed {
             tracing::info!(script = %name, "Script removed from config, stopping");
@@ -713,7 +879,7 @@ impl DaemonCore {
 
         for name in diff.added {
             tracing::info!(script = %name, "New script in config, starting");
-            if let Err(e) = self.start_script(&name).await {
+            if let Err(e) = self.start_script(&name, config_path).await {
                 tracing::error!(script = %name, error = ?e, "Failed to start during reload");
             }
         }
@@ -724,7 +890,7 @@ impl DaemonCore {
                 tracing::error!(script = %name, error = ?e, "Failed to stop during reload");
             }
             self.cron.cancel(&name);
-            if let Err(e) = self.start_script(&name).await {
+            if let Err(e) = self.start_script(&name, config_path).await {
                 tracing::error!(script = %name, error = ?e, "Failed to start during reload");
             }
         }

--- a/src/daemon/process_supervisor.rs
+++ b/src/daemon/process_supervisor.rs
@@ -72,10 +72,11 @@ impl ProcessSupervisor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        if let Some(context) = script_def.resolved_context(config_dir) {
-            tracing::debug!(script = %name, context = %context.display(), "Setting working directory");
-            cmd.current_dir(&context);
-        }
+        let working_dir = script_def
+            .resolved_context(config_dir)
+            .unwrap_or_else(|| config_dir.to_path_buf());
+        tracing::debug!(script = %name, working_dir = %working_dir.display(), "Setting working directory");
+        cmd.current_dir(&working_dir);
 
         let extra_env = script_def.resolved_env(config_dir);
         if !extra_env.is_empty() {
@@ -221,6 +222,7 @@ impl ProcessSupervisor {
                     uptime,
                     restart_count: process.restart_count,
                     exit_code: None,
+                    config_path: None,
                 }
             })
             .collect()

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -8,6 +8,8 @@ use tokio::fs;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ScriptState {
     pub name: String,
+    #[serde(default)]
+    pub config_path: Option<PathBuf>,
     pub status: ProcessStatus,
     pub last_started: Option<DateTime<Local>>,
     pub last_stopped: Option<DateTime<Local>>,
@@ -29,7 +31,7 @@ pub struct RunningState {
 impl RunningState {
     pub fn new(state_file: PathBuf) -> Self {
         Self {
-            version: 2,
+            version: 3,
             scripts: Vec::new(),
             state_file,
             config_path: None,
@@ -39,13 +41,17 @@ impl RunningState {
     pub fn load(state_file: &PathBuf) -> Result<Self> {
         if state_file.exists() {
             let content = std::fs::read_to_string(&state_file)?;
-            let serializable: RunningState = serde_json::from_str(&content)?;
-            Ok(Self {
-                version: serializable.version,
-                scripts: serializable.scripts.into_iter().map(Into::into).collect(),
-                state_file: state_file.clone(),
-                config_path: serializable.config_path,
-            })
+            let mut state: RunningState = serde_json::from_str(&content)?;
+            state.state_file = state_file.clone();
+
+            let legacy_config_path = state.config_path.take();
+            for script in &mut state.scripts {
+                if script.config_path.is_none() {
+                    script.config_path = legacy_config_path.clone();
+                }
+            }
+
+            Ok(state)
         } else {
             Ok(RunningState::new(state_file.clone()))
         }
@@ -76,5 +82,150 @@ impl RunningState {
         self.scripts.retain(|s| s.name != name);
         self.save().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn load_old_format_migrates_config_path() {
+        let state_json = r#"{
+            "version": 2,
+            "state_file": "/tmp/state.json",
+            "config_path": "/projects/a/scripts.yml",
+            "scripts": [
+                {
+                    "name": "script1",
+                    "status": "Running",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": false,
+                    "restart_count": 0
+                },
+                {
+                    "name": "script2",
+                    "status": "Stopped",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": true,
+                    "restart_count": 0
+                }
+            ]
+        }"#;
+
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), state_json).unwrap();
+        let state = RunningState::load(&tmp.path().to_path_buf()).unwrap();
+
+        assert_eq!(state.scripts.len(), 2);
+        assert_eq!(
+            state.scripts[0].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/a/scripts.yml"))
+        );
+        assert_eq!(
+            state.scripts[1].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/a/scripts.yml"))
+        );
+        assert!(state.config_path.is_none());
+    }
+
+    #[test]
+    fn load_new_format_preserves_per_script_config_path() {
+        let state_json = r#"{
+            "version": 3,
+            "state_file": "/tmp/state.json",
+            "scripts": [
+                {
+                    "name": "script1",
+                    "config_path": "/projects/a/scripts.yml",
+                    "status": "Running",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": false,
+                    "restart_count": 0
+                },
+                {
+                    "name": "script2",
+                    "config_path": "/projects/b/scripts.yml",
+                    "status": "Stopped",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": true,
+                    "restart_count": 0
+                }
+            ]
+        }"#;
+
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), state_json).unwrap();
+        let state = RunningState::load(&tmp.path().to_path_buf()).unwrap();
+
+        assert_eq!(state.scripts.len(), 2);
+        assert_eq!(
+            state.scripts[0].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/a/scripts.yml"))
+        );
+        assert_eq!(
+            state.scripts[1].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/b/scripts.yml"))
+        );
+    }
+
+    #[test]
+    fn load_mixed_format_migrates_only_missing() {
+        let state_json = r#"{
+            "version": 2,
+            "state_file": "/tmp/state.json",
+            "config_path": "/projects/legacy/scripts.yml",
+            "scripts": [
+                {
+                    "name": "has_path",
+                    "config_path": "/projects/explicit/scripts.yml",
+                    "status": "Running",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": false,
+                    "restart_count": 0
+                },
+                {
+                    "name": "no_path",
+                    "status": "Stopped",
+                    "last_started": null,
+                    "last_stopped": null,
+                    "exit_code": null,
+                    "explicitly_stopped": false,
+                    "restart_count": 0
+                }
+            ]
+        }"#;
+
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), state_json).unwrap();
+        let state = RunningState::load(&tmp.path().to_path_buf()).unwrap();
+
+        assert_eq!(
+            state.scripts[0].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/explicit/scripts.yml"))
+        );
+        assert_eq!(
+            state.scripts[1].config_path.as_deref(),
+            Some(std::path::Path::new("/projects/legacy/scripts.yml"))
+        );
+    }
+
+    #[test]
+    fn load_nonexistent_file_creates_empty_state() {
+        let state = RunningState::load(&PathBuf::from("/nonexistent/state.json")).unwrap();
+        assert_eq!(state.version, 3);
+        assert!(state.scripts.is_empty());
+        assert!(state.config_path.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Store `config_path` per-script in state (instead of one global path), enabling multiple `scripts.yml` from different projects to coexist without interference
- Fix cron restore bug: after daemon restart, cron schedules are now re-registered for all cron-scripts (not just running ones), fix `th down`/`th ps` scoping to current config only, add `th list` for global view, and default working directory to config dir when `context` is not set
- Add name collision detection: `th up` returns a clear error if a script name is already registered from a different config

## Test plan
- [x] `cargo test` — 24 tests pass, 0 warnings
- [x] `cargo build --release` — compiles cleanly
- [ ] Manual: run `th up` from two different project dirs with separate `scripts.yml`, verify `th ps` shows only current project's scripts
- [ ] Manual: run `th list` to see all scripts with CONFIG column
- [ ] Manual: run `th down` in one project, verify other project's scripts are unaffected
- [ ] Manual: restart daemon, verify cron scripts resume scheduling
- [ ] Manual: verify scripts without `context` field run from config directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)