### PR TITLE
ci(release): add Homebrew caveat to run th install after upgrading

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,10 @@ jobs:
               bin.install "turtled"
             end
 
+            def caveats
+              "Daemon runs from a fixed path so Full Disk Access survives upgrades; after 'brew upgrade' run 'th install' to refresh the daemon binary (FDA preserved, no re-grant)."
+            end
+
             test do
               assert_match "turtle-harbor", shell_output("\#{bin}/th --help")
             end


### PR DESCRIPTION
## Summary
- After the FDA-durability fix (#21), the daemon runs from a fixed path under Application Support, and that copy must be refreshed after each `brew upgrade` via `th install` (FDA is preserved, no re-grant).
- Adds a Homebrew `caveats` block to the generated formula so `brew install`/`brew upgrade turtle-harbor` prints a reminder to run `th install`.

## Test plan
- Single-line caveat string, no backticks/`$`/`#`, safe inside the formula heredoc.
- Takes effect on the next release (the homebrew job regenerates the formula). After that: `brew upgrade turtle-harbor` shows the caveat in its output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
